### PR TITLE
LINK-1923 | Add missing information to documentation

### DIFF
--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -2308,9 +2308,11 @@ components:
       properties:
         id:
           type: string
+          maxLength: 100
           description: Consists of source prefix and source specific identifier. These should be URIs uniquely identifying the place, and preferably also well formed http-URLs pointing to more information about the place.
         origin_id:
           type: string
+          maxLength: 100
           description: Place identifier in the originating system. Same as id but without the data source prefix.
         data_source:
           type: string
@@ -2351,22 +2353,28 @@ components:
                 type: string
         email:
           type: string
+          maxLength: 254
           description: Contact email for the place, note that this is NOT multilingual
         contact_type:
           type: string
+          maxLength: 255
           description: |
             FIXME: this seems unused in Helsinki data. Does any 6Aika city have use for describing contact type?
         address_region:
           type: string
+          maxLength: 255
           description: Larger region for address (like states), not typically used in Finland
         postal_code:
           type: string
+          maxLength: 128
           description: Postal code of the location (as used by traditional mail)
         post_office_box_num:
           type: string
+          maxLength: 128
           description: PO box for traditional mail, in case mail is not delivered to the building
         address_country:
           type: string
+          maxLength: 2
           description: Country for the place, NOT multilingual
         deleted:
           type: boolean
@@ -2404,11 +2412,49 @@ components:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 255
+                sv:
+                  type: string
+                  maxLength: 255
+                en:
+                  type: string
+                  maxLength: 255
+                ar:
+                  type: string
+                  maxLength: 255
+                ru:
+                  type: string
+                  maxLength: 255
+                zh_hans:
+                  type: string
+                  maxLength: 255
               description: Name of the place, multilingual
         street_address:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 255
+                sv:
+                  type: string
+                  maxLength: 255
+                en:
+                  type: string
+                  maxLength: 255
+                ar:
+                  type: string
+                  maxLength: 255
+                ru:
+                  type: string
+                  maxLength: 255
+                zh_hans:
+                  type: string
+                  maxLength: 255
               description: Street address for the place, multilingual
         info_url:
           allOf:
@@ -2416,16 +2462,28 @@ components:
             - type: object
               properties:
                 fi:
+                  type: string
+                  maxLength: 1000
                   format: url
                 sv:
+                  type: string
+                  maxLength: 1000
                   format: url
                 en:
+                  type: string
+                  maxLength: 1000
                   format: url
                 ar:
+                  type: string
+                  maxLength: 1000
                   format: url
                 ru:
+                  type: string
+                  maxLength: 1000
                   format: url
                 zh_hans:
+                  type: string
+                  maxLength: 1000
                   format: url
               description: Link (URL) to a page with more information about place
         description:
@@ -2438,11 +2496,49 @@ components:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 255
+                sv:
+                  type: string
+                  maxLength: 255
+                en:
+                  type: string
+                  maxLength: 255
+                ar:
+                  type: string
+                  maxLength: 255
+                ru:
+                  type: string
+                  maxLength: 255
+                zh_hans:
+                  type: string
+                  maxLength: 255
               description: Describes where the address is located, typically this would be name of the city.
         telephone:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 128
+                sv:
+                  type: string
+                  maxLength: 128
+                en:
+                  type: string
+                  maxLength: 128
+                ar:
+                  type: string
+                  maxLength: 128
+                ru:
+                  type: string
+                  maxLength: 128
+                zh_hans:
+                  type: string
+                  maxLength: 128
               description: Contact phone number for the place, multilingual
       description: Places describe physical locations for events and means for contacting people responsible for these locations. Place definitions come from organizations publishing events (field "publisher") and can thus have slightly different semantics between places sourced from different organizations.
     image:
@@ -2480,15 +2576,19 @@ components:
           readOnly: true
         name:
           type: string
+          maxLength: 255
           description: Image description
         url:
           type: string
+          maxLength: 400
+          format: url
           description: The image file URL
         cropping:
           type: string
           description: Cropping data for the image
         photographer_name:
           type: string
+          maxLength: 255
           description: Photographer of the image
         data_source:
           type: string
@@ -2502,6 +2602,25 @@ components:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 320
+                sv:
+                  type: string
+                  maxLength: 320
+                en:
+                  type: string
+                  maxLength: 320
+                ar:
+                  type: string
+                  maxLength: 320
+                ru:
+                  type: string
+                  maxLength: 320
+                zh_hans:
+                  type: string
+                  maxLength: 320
               description: The image alt text, multilingual.
       description: Images are used as pictures for events, places and organizers.
     organization:
@@ -2514,9 +2633,11 @@ components:
       properties:
         id:
           type: string
+          maxLength: 255
           description: Consists of source prefix and source specific identifier. These should be URIs uniquely identifying the organization, and preferably also well formed http-URLs pointing to more information about the organization.
         origin_id:
           type: string
+          maxLength: 255
           description:
             Identifier for the organization in the original data source.
             For standardized namespaces this will be a shared identifier.
@@ -2530,6 +2651,7 @@ components:
           description: Id of the organization type
         name:
           type: string
+          maxLength: 255
           description: The name of the organization
         founding_date:
           type: string
@@ -2583,12 +2705,10 @@ components:
         - type: object
           required:
             - origin_id
-            - admin_users
-            - registration_admin_users
-            - regular_users
           properties:
             origin_id:
               type: string
+              maxLength: 255
               description:
                 Identifier for the organization in the data source of this organization.
                 For standardized namespaces this will be a shared identifier.
@@ -2628,9 +2748,11 @@ components:
       properties:
         id:
           type: string
+          maxLength: 100
           description: Identifier of the data source
         name:
           type: string
+          maxLength: 255
           description: Identifier of the data source
         user_editable_resources:
           type: boolean
@@ -2662,9 +2784,11 @@ components:
       properties:
         id:
           type: string
+          maxLength: 255
           description: Consists of source prefix and source specific identifier.
         name:
           type: string
+          maxLength: 255
           description: The name of the organization class
         created_time:
           type: string
@@ -2688,9 +2812,11 @@ components:
       properties:
         id:
           type: string
+          maxLength: 100
           description: Consists of source prefix and source specific identifier. These should be URIs uniquely identifying the keyword, and preferably also well formed http-URLs pointing to more information about the keyword.
         origin_id:
           type: string
+          maxLength: 100
           description:
             Identifier for the keyword in the organization using this keyword.
             For standardized namespaces this will be a shared identifier.
@@ -2748,6 +2874,25 @@ components:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 255
+                sv:
+                  type: string
+                  maxLength: 255
+                en:
+                  type: string
+                  maxLength: 255
+                ar:
+                  type: string
+                  maxLength: 255
+                ru:
+                  type: string
+                  maxLength: 255
+                zh_hans:
+                  type: string
+                  maxLength: 255
               description: Keyword name, multilingual
       description: |
         Keywords are used to describe events. Linked events uses namespaced
@@ -2767,10 +2912,12 @@ components:
       properties:
         id:
           type: string
+          maxLength: 100
           description: Unique identifier for this keyword set.
             These should be URIs identifying the source and the keyword set itself, and preferably also well formed http-URLs pointing to more information about the keyword.
         origin_id:
           type: string
+          maxLength: 100
           description: Set identifier in the originating system, if any
         keywords:
           type: array
@@ -2816,6 +2963,25 @@ components:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 255
+                sv:
+                  type: string
+                  maxLength: 255
+                en:
+                  type: string
+                  maxLength: 255
+                ar:
+                  type: string
+                  maxLength: 255
+                ru:
+                  type: string
+                  maxLength: 255
+                zh_hans:
+                  type: string
+                  maxLength: 255
           description: Name for this keyword set, multilingual. This should be human readable, such that it could be shown as label in UI.
       description: Keyword sets are used to group keywords together into classification groups. For example, one set of keywords might describe themes used by an event provider and another could be used to describe audience groups.
     language:
@@ -2827,6 +2993,7 @@ components:
       properties:
         id:
           type: string
+          maxLength: 10
           description: Identifier for the language (typically ISO639-1)
         translation_available:
           type: boolean
@@ -2838,6 +3005,25 @@ components:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 20
+                sv:
+                  type: string
+                  maxLength: 20
+                en:
+                  type: string
+                  maxLength: 20
+                ar:
+                  type: string
+                  maxLength: 20
+                ru:
+                  type: string
+                  maxLength: 20
+                zh_hans:
+                  type: string
+                  maxLength: 20
           description: Translation for the language name. Properties shown here are examples, it is suggested that every language supported has its name translated to every other language. Users of the API cannot rely on any translations being present.
       description: Primary purpose of this endpoint is to allow users to identify which languages are supported for multilingual fields. It also has translations for the names of the languages.
     event:
@@ -2959,18 +3145,22 @@ components:
             Key value field for custom data.
         user_name:
           type: string
+          maxLength: 50
           description: |
             Name of the external user.
         user_email:
           type: string
+          maxLength: 254
           description: |
             Email of the external user.
         user_phone_number:
           type: string
+          maxLength: 18
           description: |
             Phone number of the external user.
         user_organization:
           type: string
+          maxLength: 255
           description: |
             Organization of the external user.
         user_consent:
@@ -2985,6 +3175,7 @@ components:
             - out
         environmental_certificate:
           type: string
+          maxLength: 255
           description: |
             Url of the environmental certificate.
         audience_min_age:
@@ -3035,32 +3226,101 @@ components:
             - type: object
               properties:
                 fi:
+                  type: string
+                  maxLength: 1000
                   format: url
                 sv:
+                  type: string
+                  maxLength: 1000
                   format: url
                 en:
+                  type: string
+                  maxLength: 1000
                   format: url
                 ar:
+                  type: string
+                  maxLength: 1000
                   format: url
                 ru:
+                  type: string
+                  maxLength: 1000
                   format: url
                 zh_hans:
+                  type: string
+                  maxLength: 1000
                   format: url
               description: Link (URL) to a page with more information about event
         name:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 255
+                sv:
+                  type: string
+                  maxLength: 255
+                en:
+                  type: string
+                  maxLength: 255
+                ar:
+                  type: string
+                  maxLength: 255
+                ru:
+                  type: string
+                  maxLength: 255
+                zh_hans:
+                  type: string
+                  maxLength: 255
               description: Short descriptive name for the event, recommended limit 80 characters
         provider:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 512
+                sv:
+                  type: string
+                  maxLength: 512
+                en:
+                  type: string
+                  maxLength: 512
+                ar:
+                  type: string
+                  maxLength: 512
+                ru:
+                  type: string
+                  maxLength: 512
+                zh_hans:
+                  type: string
+                  maxLength: 512
               description: Description of who is responsible for the practical implementation of the event
         location_extra_info:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 400
+                sv:
+                  type: string
+                  maxLength: 400
+                en:
+                  type: string
+                  maxLength: 400
+                ar:
+                  type: string
+                  maxLength: 400
+                ru:
+                  type: string
+                  maxLength: 400
+                zh_hans:
+                  type: string
+                  maxLength: 400
               description: Unstructured extra info about location (like "eastern door of railway station")
         short_description:
           allOf:
@@ -3076,6 +3336,25 @@ components:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 10000
+                sv:
+                  type: string
+                  maxLength: 10000
+                en:
+                  type: string
+                  maxLength: 10000
+                ar:
+                  type: string
+                  maxLength: 10000
+                ru:
+                  type: string
+                  maxLength: 10000
+                zh_hans:
+                  type: string
+                  maxLength: 10000
               description: Provide's contact information, multilingual
       description: |
         Describes the actual events. Linked events API supports organizing
@@ -3106,34 +3385,70 @@ components:
             - type: object
               properties:
                 fi:
+                  type: string
+                  maxLength: 1000
                   format: url
                 sv:
+                  type: string
+                  maxLength: 1000
                   format: url
                 en:
+                  type: string
+                  maxLength: 1000
                   format: url
                 ar:
+                  type: string
+                  maxLength: 1000
                   format: url
                 ru:
+                  type: string
+                  maxLength: 1000
                   format: url
                 zh_hans:
+                  type: string
+                  maxLength: 1000
                   format: url
               description: Link (URL) to a page with more information about offer
         price:
           allOf:
             - $ref: "#/components/schemas/multilingual_object"
             - type: object
+              properties:
+                fi:
+                  type: string
+                  maxLength: 1000
+                sv:
+                  type: string
+                  maxLength: 1000
+                en:
+                  type: string
+                  maxLength: 1000
+                ar:
+                  type: string
+                  maxLength: 1000
+                ru:
+                  type: string
+                  maxLength: 1000
+                zh_hans:
+                  type: string
+                  maxLength: 1000
               description: Price of the event. These are not bare numbers but instead descriptions of the pricing scheme.
 
       description: Information record for this event. The prices are not in a structured format and the format depends on information source. An exception to this is the case of free event. These are indicated using is_free flag, which is searchable.
     eventlink:
       title: Link to related information
       type: object
+      required:
+        - link
+        - language
       properties:
         name:
           type: string
+          maxLength: 100
           description: Name describing contents of the link
         link:
           type: string
+          maxLength: 200
           description: link to an external related entity
         language:
           type: string
@@ -3142,45 +3457,55 @@ components:
     video:
       title: Event video
       type: object
+      required:
+        - url
       properties:
         name:
           type: string
+          maxLength: 255
           description: Name describing contents of the video
         url:
           type: string
+          maxLength: 200
           description: Url to a video
         alt_text:
           type: string
+          maxLength: 320
           description: The video alt text
       description: Links to videos that the event publisher considers related to this event.
     signup:
       title: Signup
       type: object
-      required:
-        - notifications
       properties:
         id:
           type: integer
           description: Unique identifier for this signup
           readOnly: true
-        name:
+        first_name:
           type: string
-          description: Attendee´s name
-          example: User´s name
+          maxLength: 50
+          description: Attendee´s first name
+        last_name:
+          type: string
+          maxLength: 50
+          description: Attendee´s last name
         date_of_birth:
           type: string
           description: Attendee´s birth date
           format: date
         street_address:
           type: string
+          maxLength: 500
           description: The street address of the attendee's address
           example: Test address
         zipcode:
           type: string
+          maxLength: 10
           description: The postal number of the attendee's address
           example: 00100
         city:
           type: string
+          maxLength: 50
           description: The city of the attendee's address
           example: Helsinki
         extra_info:
@@ -3188,9 +3513,14 @@ components:
           description: Extra information about the attendee
         attendee_status:
           type: string
+          maxLength: 25
           description: Status of the attendee. Options are "attending" and "waitlisted".
-          readOnly: true
           example: attending
+        presence_status:
+          type: string
+          maxLength: 25
+          description: Event presence status of the attendee. Options are "present" and "not_present".
+          example: present
         registration:
           type: integer
           description: Id of the registration to which this signup is related
@@ -3258,8 +3588,6 @@ components:
     signup_group:
       title: Signup group
       type: object
-      required:
-        - notifications
       properties:
         id:
           type: integer
@@ -3324,7 +3652,7 @@ components:
           description: Information of the group´s contact person.
           $ref: "#/components/schemas/contact_person"
         signups:
-          type: array
+          type: arrays
           description: The list of persons to enrol to a registration as members of the same group
           items:
             $ref: "#/components/schemas/signup"
@@ -3379,16 +3707,20 @@ components:
           readOnly: true
         first_name:
           type: string
+          maxLength: 50
           description: Contact person´s first name
         last_name:
           type: string
+          maxLength: 50
           description: Contact person´s last name
         email:
           type: string
+          maxLength: 254
           description: Contact person´s email address
           format: email
         phone_number:
           type: string
+          maxLength: 18
           description: Contact person´s phone number
           example: 0441234567
         native_language:
@@ -3401,9 +3733,11 @@ components:
           example: fi
         membership_number:
           type: string
+          maxLength: 50
           description: Contact person´s membership number
         notifications:
           type: string
+          maxLength: 25
           description: Methods to send notifications to the contact person. Options are "none", "sms", "email" and "sms and email".
           example: sms and email
       description: Provides contact information for an attendee or an attendee group. In case of a group, the information will be shared for the whole group.
@@ -3412,7 +3746,6 @@ components:
       type: object
       required:
         - event
-        - mandatory_fields
       properties:
         id:
           type: integer
@@ -3496,6 +3829,7 @@ components:
           example: 5
         maximum_group_size:
           type: integer
+          minimum: 1
           description: Maximum number of people allowed to register per group
           example: 3
         confirmation_message:
@@ -3513,6 +3847,7 @@ components:
           description: Mandatory fields in the enrolment form.
           items:
             type: string
+            maxLength: 16
           example: ["name", "street_address", "zipcode", "city"]
         registration_user_accesses:
           type: array
@@ -3523,6 +3858,8 @@ components:
     registration_user_access:
       title: Registration user accesses
       type: object
+      required:
+        - email
       properties:
         id:
           type: integer
@@ -3530,7 +3867,8 @@ components:
           readOnly: true
         email:
           type: string
-          description: Email address of the registration user. Must end with one of the allowed domain names if "is_substitute_user" is set to True (by default, only "hel.fi" domain is allowed).
+          maxLength: 254
+          description: Email address of the registration user. Unique per registration. Must end with one of the allowed domain names if "is_substitute_user" is set to True (by default, only "hel.fi" domain is allowed).
         language:
           type: string
           description: The registration user's service language that should be used in invitation emails.

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -943,12 +943,20 @@ paths:
     get:
       tags:
         - language
-      summary: Return a list of languages used for describing events
-      description: The returned list describes languages used for describing events in this Linked events instance.
+      summary: Return a list of languages used for describing events and registrations
+      description: |
+        <h2 id="using-language-endpoint">Using the language endpoint</h2>
+        <p>Returns the list of languages used for describing events and registrations in this Linked events instance. The languages are also used when translating the user interface and email messages for end-users.</p>
+        
+        <h4 id="showing-service-languages">Showing service languages</h4>
+        <p>By default, all languages are shown. To show only service languages or languages that are not service languages, you can use the boolean parameter <code>service_language</code>.</p>
+        <p>For example:</p>
+        <pre><code>language/?service_language=true</code></pre>
       operationId: language_list
       parameters:
         - $ref: "#/components/parameters/page_param"
         - $ref: "#/components/parameters/pagesize_param"
+        - $ref: "#/components/parameters/language_service_language_param"
       responses:
         200:
           description: Language list
@@ -4142,6 +4150,13 @@ components:
       description: Sort the returned keyword sets in the given order. Possible sorting criteria are <code>name</code>, <code>usage</code> and <code>data_source</code>.
       schema:
         type: string
+
+    language_service_language_param:
+      name: service_language
+      in: query
+      description: Show only service languages or languages that are not service languages.
+      schema:
+        type: boolean
 
     organization_child_param:
       name: child

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -284,7 +284,7 @@ paths:
         <p>The most common event categories are listed in the two keyword sets <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:topics/">helsinki:topics</a> and <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:audiences/">helsinki:audiences</a>, which list the YSO keywords that are present in most events to specify event main topic and audience.</p>
 
         <h4 id="keyword-text">Keyword text</h4>
-        <p>To find keywords that contain a specific string, use the query parameter <code>text</code> or <code>filter</code>. Both <code>text</code> and <code>filter</code> work the same way and are just alternative parameter names.</p>
+        <p>To find keywords that contain a specific string, use the query parameter <code>text</code> or <code>filter</code>. Both <code>text</code> and <code>filter</code> work the same way, but the latter can be used, for example, with typeahead.js.</p>
         <p>Example:</p>
         <pre><code>keyword/?text=lapset</code></pre>
 
@@ -772,7 +772,7 @@ paths:
         <p>Here, locations for events are listed. Events in each location can be found at the <code>event</code> endpoint using the query parameter <code>location</code>. Most locations use the id format <code>tprek:28473</code>. An easy way to locate service points is to browse our <a href="https://servicemap.hel.fi">Service Map</a>, which uses the same location ids, e.g. <code>servicemap.hel.fi/unit/28473</code>. Default ordering is decreasing order by the number of events found.</p>
 
         <h4 id="place-text">Place text</h4>
-        <p>To find places that contain a specific string, use the query parameter <code>text</code>.</p>
+        <p>To find places that contain a specific string, use the query parameter <code>text</code> or <code>filter</code>. Both <code>text</code> and <code>filter</code> work the same way, but the latter can be used, for example, with typeahead.js.</p></p>
         <p>Example:</p>
         <pre><code>place/?text=tuomiokirkko</code></pre>
 
@@ -4201,7 +4201,7 @@ components:
     place_text_param:
       name: text
       in: query
-      description: Search for places that contain the given string. This applies even when show_all_places is specified.
+      description: Search for places that contain the given string. This applies even when show_all_places is specified. Alternative name for the parameter is <code>filter</code>.
       schema:
         type: string
 

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -284,7 +284,7 @@ paths:
         <p>The most common event categories are listed in the two keyword sets <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:topics/">helsinki:topics</a> and <a href="https://api.hel.fi/linkedevents/v1/keyword_set/helsinki:audiences/">helsinki:audiences</a>, which list the YSO keywords that are present in most events to specify event main topic and audience.</p>
 
         <h4 id="keyword-text">Keyword text</h4>
-        <p>To find keywords that contain a specific string, use the query parameter <code>text</code>.</p>
+        <p>To find keywords that contain a specific string, use the query parameter <code>text</code> or <code>filter</code>. Both <code>text</code> and <code>filter</code> work the same way and are just alternative parameter names.</p>
         <p>Example:</p>
         <pre><code>keyword/?text=lapset</code></pre>
 
@@ -314,7 +314,7 @@ paths:
         <pre><code>keyword/?show_deprecated=true</code></pre>
 
         <h4 id="ordering">Ordering</h4>
-        <p>Default ordering is decreasing order by the number of events found. You may also order results by <code>name</code>.</p>
+        <p>Default ordering is primarily decreasing order by data_source, secondarily decreasing order by the number of events found and tertiarily ascending order by name. You may order results by <code>n_events</code>, <code>id</code>, <code>name</code> and <code>data_source</code>.</p>
         <p>For example:</p>
         <pre><code>keyword/?sort=name</code></pre>
       operationId: keyword_list
@@ -4119,14 +4119,14 @@ components:
     keyword_sort_param:
       name: sort
       in: query
-      description: Sort the returned keywords in the given order. Possible sorting criteria are <code>n_events</code>, <code>id</code>, <code>name</code>, <code>data_source</code>. The default ordering is <code>-data_source</code>, <code>-n_events</code>.
+      description: Sort the returned keywords in the given order. Possible sorting criteria are <code>n_events</code>, <code>id</code>, <code>name</code> and <code>data_source</code>. The default ordering is <code>-data_source</code>, <code>-n_events</code>, <code>name</code>.
       schema:
         type: string
     keyword_text_param:
       name: text
       in: query
       description: |
-        Search for keywords (**note**: NOT events) that contain the given string. This applies even when show_all_keywords is specified.
+        Search for keywords (**note**: NOT events) that contain the given string. This applies even when show_all_keywords is specified. Alternative name for the parameter is <code>filter</code>.
       schema:
         type: string
 

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -3501,15 +3501,18 @@ components:
       properties:
         id:
           type: integer
-          description: Unique identifier for this registration
+          description: Unique identifier for this registration.
           readOnly: true
         email:
           type: string
-          description: Email address of the registration user
+          description: Email address of the registration user. Must end with one of the allowed domain names if "is_substitute_user" is set to True (by default, only "hel.fi" domain is allowed).
         language:
           type: string
           description: The registration user's service language that should be used in invitation emails.
           example: fi
+        is_substitute_user:
+          type: boolean
+          description: Determines if the registration user is a substitute user for the creator of the registration. A substitute user has full administration rights for the registration. The registration user's email must end with an allowed domain name to be able to set this to True. By default, only "hel.fi" domain is allowed.
       description: List of email addresses which has registration specific permissions.
     seats_reservation:
       title: Seat reservation

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -3652,7 +3652,7 @@ components:
           description: Information of the group´s contact person.
           $ref: "#/components/schemas/contact_person"
         signups:
-          type: arrays
+          type: array
           description: The list of persons to enrol to a registration as members of the same group
           items:
             $ref: "#/components/schemas/signup"

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1947,6 +1947,11 @@ paths:
         <p>You may use the query parameter <code>attendee_status</code>, comma separated, to get only signups with specific attendee status.
         <p>Example:</p>
         <pre><code>signup/?attendee_status=attending</code></pre>
+        
+        <h3 id="signup-ordering">Ordering</h3>
+        <p>Default ordering is ascending alphabetical order primarily by <code>first_name</code> and secondarily by <code>last_name</code> which are also the only ordering parameters currently. Descending order is denoted by adding <code>-</code> in front of a parameter.</p>
+        <p>Example:</p>
+        <pre><code>signup/?sort=-first_name</code></pre>
       operationId: Signup_list
       tags:
         - signup
@@ -1970,6 +1975,7 @@ paths:
         - $ref: "#/components/parameters/signup_registration_param"
         - $ref: "#/components/parameters/signup_text_param"
         - $ref: "#/components/parameters/signup_attendee_status_param"
+        - $ref: "#/components/parameters/signup_sort_param"
     post:
       summary: Create new signups to the registration
       operationId: signup_create
@@ -4222,6 +4228,12 @@ components:
       name: attendee_status
       in: query
       description: Search for signups with the given attendee status. Multiple types are separated by comma.
+      schema:
+        type: string
+    signup_sort_param:
+      name: sort
+      in: query
+      description: Sort the returned signups in the given order. Possible sorting criteria are 'first_name' and 'last_name'. The default ordering is 'first_name,last_name'.
       schema:
         type: string
 

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -1654,7 +1654,7 @@ paths:
         <p>Example:</p>
         <pre><code>registration/?text=shostakovich</code></pre>
 
-        <h3 id="event-type">Event type</h4>
+        <h3 id="event-type">Event type</h3>
         <p>You may use the query parameter <code>event_type</code>, comma separated, to get only registrations with event of specific types.
         <p>Example:</p>
         <pre><code>registration/?event_type=course</code></pre>
@@ -1666,6 +1666,11 @@ paths:
         </strong></p>
         <p>Example:</p>
         <pre><code>registration/?include=event,keywords</code></pre>
+        
+        <h3 id="registration-admin-user">Admin organization's registrations</h3>
+        <p>You may use the query parameter <code>admin_user</code>, to get only registrations whose event has been published by an organization where the user is an admin (either an event admin, registration admin or a substitute user for an admin). 
+        <p>Example:</p>
+        <pre><code>registration/?admin_user=true</code></pre>
       operationId: Registration_list
       tags:
         - registration
@@ -4223,7 +4228,7 @@ components:
     registration_admin_user_param:
       name: admin_user
       in: query
-      description: Search for registrations to which user has admin role.
+      description: Search for registrations to which user has admin role (event admin, registration admin or substitute user).
       schema:
         type: string
     registration_event_type_param:

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -128,6 +128,11 @@ paths:
         <p>To find out images that originate from a specific source system, use the query parameter <code>data_source</code>, separating values by commas if you wish to query for several data sources.</p>
         <p>Example:</p>
         <pre><code>image/?data_source=helmet</code></pre>
+        
+        <h3 id="image-created-by">Images created by the authenticated user</h3>
+        <p>To find out images that have been created by the current authenticated user, use the parameter <code>created_by</code>.</p>
+        <p>Example:</p>
+        <pre><code>image/?created_by=true</code></pre>
 
         <h4 id="ordering">Ordering</h4>
         <p>Default ordering is descending order by <code>-last_modified_time</code>. You may also order results by <code>id</code> and <code>name</code>.</p>
@@ -141,6 +146,7 @@ paths:
         - $ref: "#/components/parameters/image_text_param"
         - $ref: "#/components/parameters/image_publisher_param"
         - $ref: "#/components/parameters/image_data_source_param"
+        - $ref: "#/components/parameters/image_created_by_param"
         - $ref: "#/components/parameters/image_sort_param"
 
       responses:
@@ -4048,6 +4054,12 @@ components:
       schema:
         type: string
 
+    image_created_by_param:
+      name: created_by
+      in: query
+      description: Search for images created by the authenticated user.
+      schema:
+        type: boolean
     image_data_source_param:
       name: data_source
       in: query


### PR DESCRIPTION
### Description
Adds and updates various missing information to the Swagger documentation:

- how to user substitute user access through registration user access (registration user access endpoint only)
- available filtering and ordering parameters (various endpoints)
- maximum length of string fields & required field information (various endpoints)
### Closes
[LINK-1923](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1923)

[LINK-1923]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ